### PR TITLE
Fix memory allocation problem.

### DIFF
--- a/include/arlnsmat.h
+++ b/include/arlnsmat.h
@@ -436,9 +436,9 @@ void ARluNonSymMatrix<ARTYPE, ARFLOAT>::FactorAsI(ARTYPE sigma)
 
   // Creating a temporary matrix AsI.
 
-  irowi = new int[nnz+this->n];
-  pcoli = new int[this->n+1];
-  asi   = new ARTYPE[nnz+this->n];
+  irowi = (int*)malloc(sizeof(int) * (nnz+this->n));
+  pcoli = (int*)malloc(sizeof(int) * (this->n+1));
+  asi   = (ARTYPE*)malloc(sizeof(ARTYPE) * (nnz+this->n));
   Create_CompCol_Matrix(&AsI, this->n,  this->n, nnz, asi, irowi, pcoli, SLU_NC, SLU_GE);
 
   // Subtracting sigma*I from A and storing the result on AsI.

--- a/include/arlsmat.h
+++ b/include/arlsmat.h
@@ -396,9 +396,9 @@ void ARluSymMatrix<ARTYPE>::FactorA()
 
   // Creating a temporary matrix Aexp.
 
-  irowi = new int[nnz*2];
-  pcoli = new int[this->n+1];
-  aexp  = new ARTYPE[nnz*2];
+  irowi = (int*)malloc(sizeof(int) * (nnz*2));
+  pcoli = (int*)malloc(sizeof(int) * (this->n+1));
+  aexp  = (ARTYPE*)malloc(sizeof(ARTYPE) * (nnz*2));
   Create_CompCol_Matrix(&Aexp, this->n,  this->n, nnz, aexp, irowi, pcoli, SLU_NC, SLU_GE);
 
   // Expanding A.
@@ -517,9 +517,9 @@ void ARluSymMatrix<ARTYPE>::FactorAsI(ARTYPE sigma)
 
   // Creating a temporary matrix AsI.
 
-  irowi = new int[nnz*2+this->n];
-  pcoli = new int[this->n+1];
-  asi   = new ARTYPE[nnz*2+this->n];
+  irowi = (int*)malloc(sizeof(int) * (nnz*2+this->n));
+  pcoli = (int*)malloc(sizeof(int) * (this->n+1));
+  asi   = (ARTYPE*)malloc(sizeof(ARTYPE) * (nnz*2+this->n));
   Create_CompCol_Matrix(&AsI, this->n,  this->n, nnz, asi, irowi, pcoli, SLU_NC, SLU_GE);
 
   // Subtracting sigma*I from A and storing the result on AsI.


### PR DESCRIPTION
Since SuperLU uses C `free`, memory should not be allocated using C++ `new[]`. Instead use `malloc`.

Fixes issue #15.