### PR TITLE
Update CHOLMOD support

### DIFF
--- a/examples/cholmod/sym/csymgbkl.cc
+++ b/examples/cholmod/sym/csymgbkl.cc
@@ -1,0 +1,100 @@
+/*
+   ARPACK++ v1.2 2/20/2000
+   c++ interface to ARPACK code.
+
+   MODULE CSymGBkl.cc.
+   Example program that illustrates how to solve a real symmetric
+   generalized eigenvalue problem in buckling mode using the 
+   ARluSymGenEig class.
+
+   1) Problem description:
+
+      In this example we try to solve A*x = B*x*lambda in buckling
+      mode, where A and B are obtained from the finite element 
+      discretization of the 1-dimensional discrete Laplacian
+                                  d^2u / dx^2
+      on the interval [0,1] with zero Dirichlet boundary conditions
+      using piecewise linear elements.
+
+   2) Data structure used to represent matrices A and B:
+
+      {nnzA, irowA, pcolA, valA}: lower triangular part of matrix A 
+                                  stored in CSC format.
+      {nnzB, irowB, pcolB, valB}: lower triangular part of matrix B 
+                                  stored in CSC format.
+
+   3) Library called by this example:
+
+      The CHOLMOD package is called by ARluSymGenEig to solve
+      some linear systems involving (A-sigma*B).
+
+   4) Included header files:
+
+      File             Contents
+      -----------      -------------------------------------------
+      lsmatrxc.h       SymmetricMatrixC, a function that generates
+                       matrix A in CSC format.
+      lsmatrxd.h       SymmetricMatrixD, a function that generates
+                       matrix B in CSC format.
+      arcsmat.h        The ARluSymMatrix class definition.
+      arcgsym.h        The ARluSymGenEig class definition.
+      lsymsol.h        The Solution function.
+
+   5) ARPACK Authors:
+
+      Richard Lehoucq
+      Kristyn Maschhoff
+      Danny Sorensen
+      Chao Yang
+      Dept. of Computational & Applied Mathematics
+      Rice University
+      Houston, Texas
+*/
+
+#include "lsmatrxc.h"
+#include "lsmatrxd.h"
+#include "arcsmat.h"
+#include "arcgsym.h"
+#include "lsymsol.h"
+
+
+int main()
+{
+
+  int    n;              // Dimension of the problem.
+  int    nnzA,   nnzB;   // Number of nonzero elements in A and B.
+  int    *irowA, *irowB; // pointer to an array that stores the row
+                         // indices of the nonzeros in A and B.
+  int    *pcolA, *pcolB; // pointer to an array of pointers to the
+                         // beginning of each column of A (B) in valA (valB).
+  double *valA,  *valB;  // pointer to an array that stores the nonzero
+                         // elements of A and B.
+
+  int nev = 4; // Number of requested eigenvalues.
+
+  // Creating matrices A and B.
+
+  n = 100;
+  SymmetricMatrixC(n, nnzA, valA, irowA, pcolA, 'U');
+  ARchSymMatrix<double> A(n, nnzA, valA, irowA, pcolA, 'U');
+
+  SymmetricMatrixD(n, nnzB, valB, irowB, pcolB, 'U');
+  ARchSymMatrix<double> B(n, nnzB, valB, irowB, pcolB, 'U');
+
+  // Defining what we need: the four eigenvectors nearest to 1.0.
+
+  ARluSymGenEig<double> dprob('B', nev, A, B, 1.0);
+
+  // Finding eigenvalues and eigenvectors.
+
+  dprob.FindEigenvectors();
+
+  // Printing solution.
+
+  Solution(A, B, dprob);
+
+  int nconv = dprob.ConvergedEigenvalues();
+  
+  return nconv < nev ? EXIT_FAILURE : EXIT_SUCCESS;
+} // main.
+

--- a/examples/cholmod/sym/csymgcay.cc
+++ b/examples/cholmod/sym/csymgcay.cc
@@ -1,0 +1,100 @@
+/*
+   ARPACK++ v1.2 2/20/2000
+   c++ interface to ARPACK code.
+
+   MODULE CSymGCay.cc.
+   Example program that illustrates how to solve a real symmetric
+   generalized eigenvalue problem in Cayley mode using the
+   ARluSymGenEig class.
+
+   1) Problem description:
+
+      In this example we try to solve A*x = B*x*lambda in Cayley
+      mode, where A and B are obtained from the finite element 
+      discretization of the 1-dimensional discrete Laplacian
+                                  d^2u / dx^2
+      on the interval [0,1] with zero Dirichlet boundary conditions
+      using piecewise linear elements.
+
+   2) Data structure used to represent matrices A and B:
+
+      {nnzA, irowA, pcolA, valA}: lower triangular part of matrix A 
+                                  stored in CSC format.
+      {nnzB, irowB, pcolB, valB}: lower triangular part of matrix B 
+                                  stored in CSC format.
+
+   3) Library called by this example:
+
+      The CHOLMOD package is called by ARluSymGenEig to solve
+      some linear systems involving (A-sigma*B).
+
+   4) Included header files:
+
+      File             Contents
+      -----------      -------------------------------------------
+      lsmatrxc.h       SymmetricMatrixC, a function that generates
+                       matrix A in CSC format.
+      lsmatrxd.h       SymmetricMatrixD, a function that generates
+                       matrix B in CSC format.
+      arcsmat.h        The ARluSymMatrix class definition.
+      arcgsym.h        The ARluSymGenEig class definition.
+      lsymsol.h        The Solution function.
+
+   5) ARPACK Authors:
+
+      Richard Lehoucq
+      Kristyn Maschhoff
+      Danny Sorensen
+      Chao Yang
+      Dept. of Computational & Applied Mathematics
+      Rice University
+      Houston, Texas
+*/
+
+#include "lsmatrxc.h"
+#include "lsmatrxd.h"
+#include "arcsmat.h"
+#include "arcgsym.h"
+#include "lsymsol.h"
+
+
+int main()
+{
+
+  int    n;              // Dimension of the problem.
+  int    nnzA,   nnzB;   // Number of nonzero elements in A and B.
+  int    *irowA, *irowB; // pointer to an array that stores the row
+                         // indices of the nonzeros in A and B.
+  int    *pcolA, *pcolB; // pointer to an array of pointers to the
+                         // beginning of each column of A (B) in valA (valB).
+  double *valA,  *valB;  // pointer to an array that stores the nonzero
+                         // elements of A and B.
+
+  int nev = 4; // Number of requested eigenvalues.
+
+  // Creating matrices A and B.
+
+  n = 100;
+  SymmetricMatrixC(n, nnzA, valA, irowA, pcolA, 'U');
+  ARchSymMatrix<double> A(n, nnzA, valA, irowA, pcolA, 'U');
+
+  SymmetricMatrixD(n, nnzB, valB, irowB, pcolB, 'U');
+  ARchSymMatrix<double> B(n, nnzB, valB, irowB, pcolB, 'U');
+
+  // Defining what we need: the four eigenvectors nearest to 150.0.
+
+  ARluSymGenEig<double> dprob('C', nev, A, B, 150.0);
+
+  // Finding eigenvalues and eigenvectors.
+
+  dprob.FindEigenvectors();
+
+  // Printing solution.
+
+  Solution(A, B, dprob);
+
+  int nconv = dprob.ConvergedEigenvalues();
+  
+  return nconv < nev ? EXIT_FAILURE : EXIT_SUCCESS;
+} // main.
+

--- a/include/arcsmat.h
+++ b/include/arcsmat.h
@@ -339,7 +339,7 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
   uplo      = uplop;
   threshold = thresholdp;
 
-  // Creating SuperMatrix A.
+  // Creating cholmod_sparse A.
   A = CholmodCreateSparse(this->n, this->n, nnz, a, irow, pcol, uplo);
 
   this->defined = true;

--- a/include/arcsmat.h
+++ b/include/arcsmat.h
@@ -50,7 +50,6 @@ class ARchSymMatrix: public ARMatrix<ARTYPE> {
   int     nnz;
   int*    irow;
   int*    pcol;
-  double  threshold;
   ARTYPE* a;
   cholmod_common c ;
   cholmod_sparse *A ; 
@@ -77,25 +76,22 @@ class ARchSymMatrix: public ARMatrix<ARTYPE> {
   void MultInvv(ARTYPE* v, ARTYPE* w);
 
   void DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp,
-                    int* pcolp, char uplop = 'L', double thresholdp = 0.1, 
-                    bool check = true);
+                    int* pcolp, char uplop = 'L', bool check = true);
 
-  ARchSymMatrix(): ARMatrix<ARTYPE>() : factoredAsB(false) { cholmod_start (&c) ;}
+  ARchSymMatrix(): ARMatrix<ARTYPE>(), factored(false) { cholmod_start(&c); }
   // Short constructor that does nothing.
 
   ARchSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp,
-                int* pcolp, char uplop = 'L', double thresholdp = 0.1,
-                bool check = true);
+                int* pcolp, char uplop = 'L', bool check = true);
   // Long constructor.
 
-  ARchSymMatrix(const std::string& name, double thresholdp = 0.1,
-                bool check = true);
+  ARchSymMatrix(const std::string& name, bool check = true);
   // Long constructor (Harwell-Boeing file).
 
-  ARchSymMatrix(const ARchSymMatrix& other) { cholmod_start (&c) ; Copy(other); }
+  ARchSymMatrix(const ARchSymMatrix& other) { cholmod_start(&c); Copy(other); }
   // Copy constructor.
 
-  virtual ~ARchSymMatrix() { ClearMem(); cholmod_finish (&c) ;}
+  virtual ~ARchSymMatrix() { ClearMem(); cholmod_finish(&c); }
   // Destructor.
 
   ARchSymMatrix& operator=(const ARchSymMatrix& other);
@@ -152,7 +148,6 @@ inline void ARchSymMatrix<ARTYPE>::Copy(const ARchSymMatrix<ARTYPE>& other)
   nnz  = other.nnz;
   irow = other.irow;
   pcol = other.pcol;
-  threshold = other.threshold;
   a = other.a;
   //c = other.c;
    
@@ -326,7 +321,7 @@ void ARchSymMatrix<ARTYPE>::MultInvv(ARTYPE* v, ARTYPE* w)
 template<class ARTYPE>
 inline void ARchSymMatrix<ARTYPE>::
 DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-             char uplop, double thresholdp, bool check)
+             char uplop, bool check)
 {
 
   this->m   = np;
@@ -337,7 +332,6 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
   pcol      = pcolp;
   pcol[this->n]   = nnz;
   uplo      = uplop;
-  threshold = thresholdp;
 
   // Creating cholmod_sparse A.
   A = CholmodCreateSparse(this->n, this->n, nnz, a, irow, pcol, uplo);
@@ -356,20 +350,19 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 template<class ARTYPE>
 inline ARchSymMatrix<ARTYPE>::
 ARchSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp,
-              int* pcolp, char uplop, double thresholdp,
-              bool check)                   : ARMatrix<ARTYPE>(np)
+              int* pcolp, char uplop, bool check) : ARMatrix<ARTYPE>(np)
 {
  cholmod_start (&c) ;
 
   factored = false;
-  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, thresholdp, check);
+  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, check);
 
 } // Long constructor.
 
 
 template<class ARTYPE>
 ARchSymMatrix<ARTYPE>::
-ARchSymMatrix(const std::string& file, double thresholdp, bool check)
+ARchSymMatrix(const std::string& file, bool check)
 {
  cholmod_start (&c) ;
 
@@ -387,7 +380,7 @@ ARchSymMatrix(const std::string& file, double thresholdp, bool check)
   if ((mat.NCols() == mat.NRows()) && (mat.IsSymmetric())) {
 
     DefineMatrix(mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), 'L', thresholdp, check);
+                 mat.RowInd(), mat.ColPtr(), 'L', check);
   }
   else {
     throw ArpackError(ArpackError::INCONSISTENT_DATA,

--- a/include/arcsmat.h
+++ b/include/arcsmat.h
@@ -82,10 +82,10 @@ class ARchSymMatrix: public ARMatrix<ARTYPE> {
   // Short constructor that does nothing.
 
   ARchSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp,
-                int* pcolp, char uplop = 'L', bool check = true);
+                int* pcolp, char uplop = 'L');
   // Long constructor.
 
-  ARchSymMatrix(const std::string& name, bool check = true);
+  ARchSymMatrix(const std::string& name);
   // Long constructor (Harwell-Boeing file).
 
   ARchSymMatrix(const ARchSymMatrix& other) { cholmod_start(&c); Copy(other); }
@@ -151,11 +151,11 @@ inline void ARchSymMatrix<ARTYPE>::Copy(const ARchSymMatrix<ARTYPE>& other)
   a = other.a;
   //c = other.c;
    
-  A = cholmod_copy_sparse(other.A,&c);
+  A = cholmod_copy_sparse(other.A, &c);
 
-  if (L) cholmod_free_factor(&L,&c);
+  if (L) cholmod_free_factor(&L, &c);
   if (factored)
-    L = cholmod_copy_factor(other.L,&c);
+    L = cholmod_copy_factor(other.L, &c);
 
 } // Copy.
 
@@ -350,21 +350,21 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 template<class ARTYPE>
 inline ARchSymMatrix<ARTYPE>::
 ARchSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp,
-              int* pcolp, char uplop, bool check) : ARMatrix<ARTYPE>(np)
+              int* pcolp, char uplop) : ARMatrix<ARTYPE>(np)
 {
- cholmod_start (&c) ;
+  cholmod_start (&c) ;
 
   factored = false;
-  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, check);
+  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, true);
 
 } // Long constructor.
 
 
 template<class ARTYPE>
 ARchSymMatrix<ARTYPE>::
-ARchSymMatrix(const std::string& file, bool check)
+ARchSymMatrix(const std::string& file)
 {
- cholmod_start (&c) ;
+  cholmod_start (&c) ;
 
   factored = false;
 
@@ -380,7 +380,7 @@ ARchSymMatrix(const std::string& file, bool check)
   if ((mat.NCols() == mat.NRows()) && (mat.IsSymmetric())) {
 
     DefineMatrix(mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), 'L', check);
+                 mat.RowInd(), mat.ColPtr(), 'L', true);
   }
   else {
     throw ArpackError(ArpackError::INCONSISTENT_DATA,

--- a/include/arcspen.h
+++ b/include/arcspen.h
@@ -174,7 +174,7 @@ DefineMatrices(ARchSymMatrix<ARTYPE>& Ap, ARchSymMatrix<ARTYPE>& Bp)
 
   if (A->n != B->n) {
     throw ArpackError(ArpackError::INCOMPATIBLE_SIZES,
-                      "ARchSymMatrix::DefineMatrices");
+                      "ARchSymPencil::DefineMatrices");
   }
 
 } // DefineMatrices.

--- a/include/arcssym.h
+++ b/include/arcssym.h
@@ -57,13 +57,13 @@ class ARluSymStdEig:
   ARluSymStdEig(int nevp, ARchSymMatrix<ARFLOAT>& A,
                 const std::string& whichp = "LM", int ncvp = 0,
                 ARFLOAT tolp = 0.0, int maxitp = 0,
-                ARFLOAT* residp = NULL, bool ishiftp = true);
+                ARFLOAT* residp = nullptr, bool ishiftp = true);
   // Long constructor (regular mode).
 
   ARluSymStdEig(int nevp, ARchSymMatrix<ARFLOAT>& A,
                 ARFLOAT sigma, const std::string& whichp = "LM", int ncvp = 0,
                 ARFLOAT tolp = 0.0, int maxitp = 0,
-                ARFLOAT* residp = NULL, bool ishiftp = true);
+                ARFLOAT* residp = nullptr, bool ishiftp = true);
   // Long constructor (shift and invert mode).
 
   ARluSymStdEig(const ARluSymStdEig& other) { Copy(other); }

--- a/include/arunsmat.h
+++ b/include/arunsmat.h
@@ -44,6 +44,7 @@ class ARumNonSymMatrix: public ARMatrix<ARTYPE> {
   double  info[UMFPACK_INFO];
   void*   Numeric;
   bool    factored;
+  double  threshold;
 
   // The input matrix
   ARSparseMatrix<ARTYPE>* mat;
@@ -88,12 +89,8 @@ class ARumNonSymMatrix: public ARMatrix<ARTYPE> {
 
   void MultInvv(ARTYPE* v, ARTYPE* w);
 
-  void DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                    double thresholdp = 0.1, bool check = true,
-                    bool owner = false); // Square.
-
   void DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                    bool check = true, bool owner = false); // Rectangular.
+                    double thresholdp = 0.1, bool check = true, bool owner = false);
 
   ARumNonSymMatrix(): ARMatrix<ARTYPE>(), factored(false), Numeric(nullptr), mat(nullptr), AsI(nullptr)
   {
@@ -101,13 +98,14 @@ class ARumNonSymMatrix: public ARMatrix<ARTYPE> {
   // Short constructor that does nothing.
 
   ARumNonSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                   double thresholdp = 0.1, bool check = true);
+                   double thresholdp = 0.1);
   // Long constructor (square matrix).
 
-  ARumNonSymMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp);
+  ARumNonSymMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
+                   double thresholdp = 0.1);
   // Long constructor (rectangular matrix).
 
-  ARumNonSymMatrix(const std::string& name, double thresholdp = 0.1, bool check = true);
+  ARumNonSymMatrix(const std::string& name, double thresholdp = 0.1);
   // Long constructor (Harwell-Boeing file).
 
   ARumNonSymMatrix(const ARumNonSymMatrix& other) { Copy(other); }
@@ -429,38 +427,8 @@ void ARumNonSymMatrix<ARTYPE, ARFLOAT>::MultInvv(ARTYPE* v, ARTYPE* w)
 
 template<class ARTYPE, class ARFLOAT>
 inline void ARumNonSymMatrix<ARTYPE, ARFLOAT>::
-DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-             double thresholdp, bool check, bool owner)
-{
-
-  // Defining member variables.
-
-  mat = new ARSparseMatrix<ARTYPE>(np, np, pcolp, irowp, ap, nnzp);
-  pA  = mat;
-
-  this->m   = np;
-  this->n   = np;
-
-  // Checking data.
-
-  if (check && !mat->Check()) {
-    throw ArpackError(ArpackError::INCONSISTENT_DATA,
-                      "ARumNonSymMatrix::DefineMatrix");
-  }
-
-  umfpack_defaults<ARTYPE>(control);
-
-  control[UMFPACK_PIVOT_TOLERANCE] = thresholdp;
-
-  this->defined = true;
-
-} // DefineMatrix (square).
-
-
-template<class ARTYPE, class ARFLOAT>
-inline void ARumNonSymMatrix<ARTYPE, ARFLOAT>::
 DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-             bool check, bool owner)
+             double thresholdp, bool check, bool owner)
 {
 
   // Defining member variables.
@@ -471,6 +439,8 @@ DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
   this->m  = mp;
   this->n  = np;
 
+  threshold = thresholdp;
+
   // Checking data.
 
   if (check && !mat->Check()) {
@@ -480,6 +450,8 @@ DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 
   umfpack_defaults<ARTYPE>(control);
 
+  control[UMFPACK_PIVOT_TOLERANCE] = thresholdp;
+
   this->defined  = true;
 
 } // DefineMatrix (rectangular).
@@ -488,31 +460,32 @@ DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 template<class ARTYPE, class ARFLOAT>
 inline ARumNonSymMatrix<ARTYPE, ARFLOAT>::
 ARumNonSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                 double thresholdp, bool check)
+                 double thresholdp)
   : ARMatrix<ARTYPE>(np), mat(nullptr), AsI(nullptr)
 {
 
   factored = false;
-  DefineMatrix(np, nnzp, ap, irowp, pcolp, thresholdp, check, false);
+  DefineMatrix(np, np, nnzp, ap, irowp, pcolp, thresholdp, true, false);
 
 } // Long constructor (square matrix).
 
 
 template<class ARTYPE, class ARFLOAT>
 inline ARumNonSymMatrix<ARTYPE, ARFLOAT>::
-ARumNonSymMatrix(int mp, int np, int nnzp, ARTYPE* ap,
-                 int* irowp, int* pcolp) : ARMatrix<ARTYPE>(mp, np), mat(nullptr), AsI(nullptr)
+ARumNonSymMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp,
+                 int* pcolp, double thresholdp)
+  : ARMatrix<ARTYPE>(mp, np), mat(nullptr), AsI(nullptr)
 {
 
   factored = false;
-  DefineMatrix(mp, np, nnzp, ap, irowp, pcolp);
+  DefineMatrix(mp, np, nnzp, ap, irowp, pcolp, thresholdp, true, false);
 
 } // Long constructor (rectangular matrix).
 
 
 template<class ARTYPE, class ARFLOAT>
 ARumNonSymMatrix<ARTYPE, ARFLOAT>::
-ARumNonSymMatrix(const std::string& name, double thresholdp, bool check)
+ARumNonSymMatrix(const std::string& name, double thresholdp)
 {
 
   factored = false;
@@ -527,11 +500,11 @@ ARumNonSymMatrix(const std::string& name, double thresholdp, bool check)
 
   if (mat.NCols() == mat.NRows()) {
     DefineMatrix(mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), thresholdp, check, true);
+                 mat.RowInd(), mat.ColPtr(), thresholdp, true, true);
   }
   else {
     DefineMatrix(mat.NRows(), mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), check, true);
+                 mat.RowInd(), mat.ColPtr(), thresholdp, true, true);
   }
 
 } // Long constructor (Harwell-Boeing file).

--- a/include/arunsmat.h
+++ b/include/arunsmat.h
@@ -89,8 +89,8 @@ class ARumNonSymMatrix: public ARMatrix<ARTYPE> {
   void MultInvv(ARTYPE* v, ARTYPE* w);
 
   void DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                    bool check = true, bool owner = false,
-                    double thresholdp = 0.1); // Square.
+                    double thresholdp = 0.1, bool check = true,
+                    bool owner = false); // Square.
 
   void DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
                     bool check = true, bool owner = false); // Rectangular.
@@ -101,13 +101,13 @@ class ARumNonSymMatrix: public ARMatrix<ARTYPE> {
   // Short constructor that does nothing.
 
   ARumNonSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                   bool check = true, double thresholdp = 0.1);
+                   double thresholdp = 0.1, bool check = true);
   // Long constructor (square matrix).
 
   ARumNonSymMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp);
   // Long constructor (rectangular matrix).
 
-  ARumNonSymMatrix(const std::string& name, bool check = true, double thresholdp = 0.1);
+  ARumNonSymMatrix(const std::string& name, double thresholdp = 0.1, bool check = true);
   // Long constructor (Harwell-Boeing file).
 
   ARumNonSymMatrix(const ARumNonSymMatrix& other) { Copy(other); }
@@ -430,7 +430,7 @@ void ARumNonSymMatrix<ARTYPE, ARFLOAT>::MultInvv(ARTYPE* v, ARTYPE* w)
 template<class ARTYPE, class ARFLOAT>
 inline void ARumNonSymMatrix<ARTYPE, ARFLOAT>::
 DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-             bool check, bool owner, double thresholdp)
+             double thresholdp, bool check, bool owner)
 {
 
   // Defining member variables.
@@ -488,12 +488,12 @@ DefineMatrix(int mp, int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 template<class ARTYPE, class ARFLOAT>
 inline ARumNonSymMatrix<ARTYPE, ARFLOAT>::
 ARumNonSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                 bool check, double thresholdp)
+                 double thresholdp, bool check)
   : ARMatrix<ARTYPE>(np), mat(nullptr), AsI(nullptr)
 {
 
   factored = false;
-  DefineMatrix(np, nnzp, ap, irowp, pcolp, check, false, thresholdp);
+  DefineMatrix(np, nnzp, ap, irowp, pcolp, thresholdp, check, false);
 
 } // Long constructor (square matrix).
 
@@ -512,7 +512,7 @@ ARumNonSymMatrix(int mp, int np, int nnzp, ARTYPE* ap,
 
 template<class ARTYPE, class ARFLOAT>
 ARumNonSymMatrix<ARTYPE, ARFLOAT>::
-ARumNonSymMatrix(const std::string& name, bool check, double thresholdp)
+ARumNonSymMatrix(const std::string& name, double thresholdp, bool check)
 {
 
   factored = false;
@@ -527,7 +527,7 @@ ARumNonSymMatrix(const std::string& name, bool check, double thresholdp)
 
   if (mat.NCols() == mat.NRows()) {
     DefineMatrix(mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), check, true, thresholdp);
+                 mat.RowInd(), mat.ColPtr(), thresholdp, check, true);
   }
   else {
     DefineMatrix(mat.NRows(), mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),

--- a/include/arunspen.h
+++ b/include/arunspen.h
@@ -147,7 +147,7 @@ void ARumNonSymPencil<ARTYPE, ARFLOAT>::FactorAsB(ARTYPE sigma)
     // Do not validate AsB since though the matrix is allocated, no
     // meaningful values are set.
 
-    AsB.DefineMatrix(A->m, A->n, nnz, a, irow, pcol, false, true);
+    AsB.DefineMatrix(A->m, A->n, nnz, a, irow, pcol, A->threshold, false, true);
 
   }
 
@@ -199,7 +199,7 @@ FactorAsB(ARFLOAT sigmaR, ARFLOAT sigmaI, char partp)
     // Do not validate AsBc since though the matrix is allocated, no
     // meaningful values are set.
 
-    AsBc.DefineMatrix(A->m, A->n, nnz, ax, ai, ap, false, true);
+    AsBc.DefineMatrix(A->m, A->n, nnz, ax, ai, ap, A->threshold, false, true);
 
   }
 

--- a/include/arunspen.h
+++ b/include/arunspen.h
@@ -292,7 +292,7 @@ DefineMatrices(ARumNonSymMatrix<ARTYPE, ARFLOAT>& Ap,
 
   if ((A->n != B->n)||(A->m != B->m)) {
     throw ArpackError(ArpackError::INCOMPATIBLE_SIZES,
-                      "ARumNonSymMatrix::DefineMatrices");
+                      "ARumNonSymPencil::DefineMatrices");
   }
 
 } // DefineMatrices.

--- a/include/arusmat.h
+++ b/include/arusmat.h
@@ -100,11 +100,10 @@ class ARumSymMatrix: public ARMatrix<ARTYPE> {
   // Short constructor that does nothing.
 
   ARumSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                char uplop = 'L', double thresholdp = 0.1, bool check = true);
+                char uplop = 'L', double thresholdp = 0.1);
   // Long constructor.
 
-  ARumSymMatrix(const std::string& name, double thresholdp = 0.1,
-                bool check = true);
+  ARumSymMatrix(const std::string& name, double thresholdp = 0.1);
   // Long constructor (Harwell-Boeing file).
 
   ARumSymMatrix(const ARumSymMatrix& other) { Copy(other); }
@@ -427,19 +426,19 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 template<class ARTYPE>
 inline ARumSymMatrix<ARTYPE>::
 ARumSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-              char uplop, double thresholdp, bool check)
+              char uplop, double thresholdp)
     : ARMatrix<ARTYPE>(np), factored(false), Numeric(nullptr),
       A(nullptr), AsI(nullptr), Afull(nullptr)
 {
 
-  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, thresholdp, check, false);
+  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, thresholdp, true, false);
 
 } // Long constructor.
 
 
 template<class ARTYPE>
 ARumSymMatrix<ARTYPE>::
-ARumSymMatrix(const std::string& file, double thresholdp, bool check)
+ARumSymMatrix(const std::string& file, double thresholdp)
     : ARMatrix<ARTYPE>(), factored(false), Numeric(nullptr),
       A(nullptr), AsI(nullptr), Afull(nullptr)
 {
@@ -454,7 +453,7 @@ ARumSymMatrix(const std::string& file, double thresholdp, bool check)
   if (mat.NCols() == mat.NRows() && mat.IsSymmetric()) {
 
     DefineMatrix(mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), 'L', thresholdp, check, true);
+                 mat.RowInd(), mat.ColPtr(), 'L', thresholdp, true, true);
   }
   else {
     throw ArpackError(ArpackError::INCONSISTENT_DATA,

--- a/include/arusmat.h
+++ b/include/arusmat.h
@@ -50,6 +50,7 @@ class ARumSymMatrix: public ARMatrix<ARTYPE> {
   void*   Numeric;
   bool    factored;
   char    uplo;
+  double  threshold;
 
   // The input matrix.
   ARSparseMatrix<ARTYPE>* A;
@@ -90,8 +91,8 @@ class ARumSymMatrix: public ARMatrix<ARTYPE> {
   void MultInvv(ARTYPE* v, ARTYPE* w);
 
   void DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                    char uplop = 'L', bool check = true, bool owner = false,
-                    double thresholdp = 0.1);
+                    char uplop = 'L', double thresholdp = 0.1, bool check = true,
+                    bool owner = false);
 
   ARumSymMatrix(): ARMatrix<ARTYPE>(), factored(false), Numeric(nullptr), A(nullptr), AsI(nullptr), Afull(nullptr)
   {
@@ -99,11 +100,11 @@ class ARumSymMatrix: public ARMatrix<ARTYPE> {
   // Short constructor that does nothing.
 
   ARumSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-                char uplop = 'L', bool check = true, double thresholdp = 0.1);
+                char uplop = 'L', double thresholdp = 0.1, bool check = true);
   // Long constructor.
 
-  ARumSymMatrix(const std::string& name, bool check = true,
-                double thresholdp = 0.1);
+  ARumSymMatrix(const std::string& name, double thresholdp = 0.1,
+                bool check = true);
   // Long constructor (Harwell-Boeing file).
 
   ARumSymMatrix(const ARumSymMatrix& other) { Copy(other); }
@@ -396,7 +397,7 @@ void ARumSymMatrix<ARTYPE>::MultInvv(ARTYPE* v, ARTYPE* w)
 template<class ARTYPE>
 inline void ARumSymMatrix<ARTYPE>::
 DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-             char uplop, bool check, bool owner, double thresholdp)
+             char uplop, double thresholdp, bool check, bool owner)
 {
   ClearMem();
 
@@ -404,6 +405,7 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
   this->n = np;
 
   uplo = uplop;
+  threshold = thresholdp;
 
   A = new ARSparseMatrix<ARTYPE>(np, np, pcolp, irowp, ap, nnzp, uplop, owner);
 
@@ -425,19 +427,19 @@ DefineMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
 template<class ARTYPE>
 inline ARumSymMatrix<ARTYPE>::
 ARumSymMatrix(int np, int nnzp, ARTYPE* ap, int* irowp, int* pcolp,
-              char uplop, bool check, double thresholdp)
+              char uplop, double thresholdp, bool check)
     : ARMatrix<ARTYPE>(np), factored(false), Numeric(nullptr),
       A(nullptr), AsI(nullptr), Afull(nullptr)
 {
 
-  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, check, false, thresholdp);
+  DefineMatrix(np, nnzp, ap, irowp, pcolp, uplop, thresholdp, check, false);
 
 } // Long constructor.
 
 
 template<class ARTYPE>
 ARumSymMatrix<ARTYPE>::
-ARumSymMatrix(const std::string& file, bool check, double thresholdp)
+ARumSymMatrix(const std::string& file, double thresholdp, bool check)
     : ARMatrix<ARTYPE>(), factored(false), Numeric(nullptr),
       A(nullptr), AsI(nullptr), Afull(nullptr)
 {
@@ -452,7 +454,7 @@ ARumSymMatrix(const std::string& file, bool check, double thresholdp)
   if (mat.NCols() == mat.NRows() && mat.IsSymmetric()) {
 
     DefineMatrix(mat.NCols(), mat.NonZeros(), (ARTYPE*)mat.Entries(),
-                 mat.RowInd(), mat.ColPtr(), 'L', check, true, thresholdp);
+                 mat.RowInd(), mat.ColPtr(), 'L', thresholdp, check, true);
   }
   else {
     throw ArpackError(ArpackError::INCONSISTENT_DATA,

--- a/include/aruspen.h
+++ b/include/aruspen.h
@@ -119,7 +119,7 @@ inline void ARumSymPencil<ARTYPE>::Expand(ARumSymMatrix<ARTYPE>* A)
         }
 
         // Memory is now owned by A.
-        A->DefineMatrix(n, nz, ax, ai, ap, 'S', true, true);
+        A->DefineMatrix(n, nz, ax, ai, ap, 'S', A->threshold, true, true);
     }
 
 }
@@ -176,7 +176,7 @@ void ARumSymPencil<ARTYPE>::FactorAsB(ARTYPE sigma)
         // Do not validate AsB since though the matrix is allocated, no
         // meaningful values are set.
 
-        AsB.DefineMatrix(A->m, nnz, ax, ai, ap, 'S', false, true);
+        AsB.DefineMatrix(A->m, nnz, ax, ai, ap, 'S', A->threshold, false, true);
     }
 
     // Subtracting sigma*B from A and storing the result on AsB.

--- a/include/aruspen.h
+++ b/include/aruspen.h
@@ -247,7 +247,7 @@ DefineMatrices(ARumSymMatrix<ARTYPE>& Ap, ARumSymMatrix<ARTYPE>& Bp)
 
   if (A->n != B->n) {
     throw ArpackError(ArpackError::INCOMPATIBLE_SIZES,
-                      "ARumSymMatrix::DefineMatrices");
+                      "ARumSymPencil::DefineMatrices");
   }
 
 } // DefineMatrices.

--- a/include/cholmodc.h
+++ b/include/cholmodc.h
@@ -68,59 +68,7 @@ inline cholmod_sparse* Create_Cholmod_Sparse_Matrix(int m, int n, int nnz,
   A->sorted = 0;
   A->packed = 1;
 
-  return A;  
-  
-  
-/*  double* hd  = new double[nnz];
-  int* hi     = new int[nnz];
-  int* hp     = new int[n+1];
-  
-  int col,j;
-  int counter=0;
-  int counter2=0;
-  for (col=0;col<n;col++) // column
-  {
-    hp[col] = counter2;
-    for (j=pcol[col];j<pcol[col+1];j++)
-    {
-      int & row = irow[counter];
-      if ((uplo == 'L' && row >= col) ||(uplo == 'U' && row <= col))
-      {
-        hd[counter2] = a[counter];
-        hi[counter2] = irow[counter];
-        counter2++;
-        //std::cout << " In : " << std::flush;
-      }
-      //else  std::cout << " Out : " << std::flush;
-
-      //std::cout << row+1 << " " << col+1 << " " << a[counter] << std::endl;
-      counter++;
-    }
-  
-  }
-  hp[n] = counter2;
-  
-  
-  cholmod_sparse* A = new cholmod_sparse;
-  A->nrow = m;
-  A->ncol = n;
-  A->nzmax = counter2;
-  A->p = hp;
-  A->i = hi;
-  A->nz = NULL;
-  A->x = hd;
-  A->z = NULL;
-  if (uplo == 'L') A->stype = -1;
-  else A->stype = 1;
-  A->itype = CHOLMOD_INT;
-  A->xtype = CHOLMOD_REAL; // real
-  A->dtype = CHOLMOD_DOUBLE; // double
-  A->sorted = 0;
-  A->packed = 1;
-  
-  //cholmod_sparse* As = cholmod_copy_sparse(A,c);
-
-  return A;*/
+  return A;
   
 } // Create_Cholmod_Sparse_Matrix (double).
 


### PR DESCRIPTION
Not too many changes here, mostly in `cholmodc.h`. It now uses `malloc` to allocate CHOLMOD structures instead of `new` (`free` was aleady used for destruction). Single precision support was only added recently, so `CHOLMOD_MAIN_VERSION` is checked for that. In theory, all types (float, double, complex&lt;float>, complex&lt;double>) should be supported now.

I reverted the changes to the order of the constructor and method arguments of the UMFPACK matrix classes. The `check` argument is still in place (you can decide about that later). Though the UMFPACK code should now be in a state compatible with the current API, I removed an unused parameter (threshold) from the CHOLMOD matrix class.

There are also some inconsistencies between the two main constructors of the ARumNonSymMatrix class (arunsmat.h). One provides `threshold` and `check` parameters, the other doesn't. To be consistent, I think the missing parameters should be added (regardless of whether you decide to remove `check` later). If you agree, I'll add the change to this PR.